### PR TITLE
Update gleam_otp and gleam_erlang to 1.0.0

### DIFF
--- a/examples/counter/gleam.toml
+++ b/examples/counter/gleam.toml
@@ -15,7 +15,7 @@ version = "1.0.0"
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 shore = { path = "../../" }
-gleam_erlang = ">= 0.34.0 and < 1.0.0"
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/examples/layouts/gleam.toml
+++ b/examples/layouts/gleam.toml
@@ -15,7 +15,7 @@ version = "1.0.0"
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 shore = { path = "../../" }
-gleam_erlang = ">= 0.34.0 and < 1.0.0"
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/examples/reader/gleam.toml
+++ b/examples/reader/gleam.toml
@@ -16,7 +16,7 @@ version = "1.0.0"
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 shore = { path = "../../" }
 simplifile = ">= 2.2.1 and < 3.0.0"
-gleam_otp = ">= 0.16.1 and < 1.0.0"
+gleam_otp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/examples/reader/src/reader.gleam
+++ b/examples/reader/src/reader.gleam
@@ -2,7 +2,6 @@ import gleam/erlang/process
 import gleam/int
 import gleam/list
 import gleam/option.{None, Some}
-import gleam/otp/task
 import gleam/result
 import gleam/string
 import shore
@@ -286,20 +285,14 @@ fn read_directory(dir: String) -> fn() -> Msg {
 fn files_info(items: List(String), work_dir: List(String)) -> fn() -> Msg {
   fn() {
     list.map(items, fn(item) {
-      fn() {
-        let path = item |> relative_path(work_dir)
-        simplifile.file_info(path)
-        |> result.try_recover(fn(_) { simplifile.link_info(path) })
-        |> result.map_error(ErrSimplifile(_, item))
-        |> result.map(fn(info) {
-          File(name: item, info:, type_: simplifile.file_info_type(info), path:)
-        })
-      }
-      |> task.async
+      let path = item |> relative_path(work_dir)
+      simplifile.file_info(path)
+      |> result.try_recover(fn(_) { simplifile.link_info(path) })
+      |> result.map_error(ErrSimplifile(_, item))
+      |> result.map(fn(info) {
+        File(name: item, info:, type_: simplifile.file_info_type(info), path:)
+      })
     })
-    |> task.try_await_all(100)
-    |> list.map(result.map_error(_, ErrTask))
-    |> list.map(result.flatten)
     |> result.all
     |> GetFilesInfo
   }
@@ -339,5 +332,4 @@ fn read(file: File) -> Msg {
 
 type Err {
   ErrSimplifile(error: simplifile.FileError, file: String)
-  ErrTask(error: task.AwaitError)
 }

--- a/gleam.toml
+++ b/gleam.toml
@@ -14,8 +14,8 @@ repository = { type = "github", user = "bgwdotdev", repo = "shore" }
 
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-gleam_erlang = ">= 0.34.0 and < 1.0.0"
-gleam_otp = ">= 0.16.1 and < 1.0.0"
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
+gleam_otp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
+  { name = "gleam_erlang", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "7E6A5234F927C4B24F8054AB1E4572206C41F9E6D5C6C02273CB7531E7E5CED0" },
+  { name = "gleam_otp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "7020E652D18F9ABAC9C877270B14160519FA0856EE80126231C505D719AD68DA" },
   { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
   { name = "gleeunit", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "A7DD6C07B7DA49A6E28796058AA89E651D233B357D5607006D70619CD89DAAAB" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.34.0 and < 1.0.0" }
-gleam_otp = { version = ">= 0.16.1 and < 1.0.0" }
+gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }


### PR DESCRIPTION
Fixes #1 

I had to change the logic of the `reader` example slightly to remove the references to `gleam/opt/task` since that module no longer exists. I'm not sure what the alternative is to it currently, so I just had it read the files synchronously for now. If you know of an alternative feel free to suggest it.