### PR TITLE
fix: typo in README (window terminal -> windows terminal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Shore makes use of the terminal CSI 2026 [Synchronized Output](https://gist.gith
 - konsole
 - gnome-console
 - st
-- window terminal
+- windows terminal
 
 ## Terminal Known Issues
 


### PR DESCRIPTION
Fix typo in README.