### PR TITLE
fix(ui): make focus work with Aligned

### DIFF
--- a/src/shore/internal.gleam
+++ b/src/shore/internal.gleam
@@ -478,6 +478,8 @@ fn do_list_focusable(
           let pos = Pos(..pos, width: pos.width - 4, height: pos.height - 2)
           do_list_focusable(pos, xs, do_list_focusable(pos, children, acc))
         }
+        Aligned(_, child) ->
+          do_list_focusable(pos, xs, do_list_focusable(pos, [child], acc))
         Layouts(l) -> {
           layout(l, pos)
           |> list.map(fn(i) { do_list_focusable(i.1, [i.0], acc) })
@@ -502,8 +504,7 @@ fn do_list_focusable(
         Button(text:, event:, ..) -> {
           do_list_focusable(pos, xs, [FocusedButton(text, event), ..acc])
         }
-        Aligned(..)
-        | BR
+        BR
         | Bar(..)
         | Bar2(..)
         | Debug

--- a/src/shore/internal.gleam
+++ b/src/shore/internal.gleam
@@ -478,8 +478,8 @@ fn do_list_focusable(
           let pos = Pos(..pos, width: pos.width - 4, height: pos.height - 2)
           do_list_focusable(pos, xs, do_list_focusable(pos, children, acc))
         }
-        Aligned(_, child) ->
-          do_list_focusable(pos, xs, do_list_focusable(pos, [child], acc))
+        Aligned(node:, ..) ->
+          do_list_focusable(pos, xs, do_list_focusable(pos, [node], acc))
         Layouts(l) -> {
           layout(l, pos)
           |> list.map(fn(i) { do_list_focusable(i.1, [i.0], acc) })


### PR DESCRIPTION
## Problem

Aligned UI nodes cannot be navigated with the focus keys.

See for example the increment and decrement buttons in the "counter" example app.

## Solution

I think this is it, works on my machine and all that! But I have only spent a few minutes looking at this source.

## Testing

Not much I'm afraid. I tested the examples and they work the same (aside from counter where the tab started working).

I also added some random aligns here and there in the counter and layouts example and could not make it break.